### PR TITLE
Bugfix in eval_household.py: load ts name ends with household id plus…

### DIFF
--- a/eval_result/eval_household.py
+++ b/eval_result/eval_household.py
@@ -8,7 +8,15 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 
-def eval_household(id):
+def eval_household(id_of_household):
+
+    # If the id is passed to this function as an integer it has to be transformed into a string.
+    if type(id_of_household) == int:
+        id_of_household = str(id_of_household)
+    elif type(id_of_household) != str:
+        # If the id is not passed in as a string then this is an type error while only int or string of int are allowed.
+        raise ValueError('Household id must either be integer or string of an integer. Given id is ' +
+                         str(id_of_household))
 
     # Load the last result data. Individual bids are given in the format
     # [id_seller, id_buyer, quantity [kWh], price*quantity [EUR]].
@@ -26,21 +34,20 @@ def eval_household(id):
         if len(this_result) > 0:
             # Case: There were at least one trade this step.
             for this_trade in this_result:
-                if this_trade[0] == id:
+                if this_trade[0] == id_of_household:
                     # Case: This household sold energy.
                     energy_sold[i] += this_trade[2]
                     energy_price[i] = this_trade[3] / this_trade[2]
-                elif this_trade[1] == id:
+                elif this_trade[1] == id_of_household:
                     # Case: This household bought energy.
                     energy_bought[i] += this_trade[2]
                     energy_price[i] = this_trade[3] / this_trade[2]
 
-
     # Load the load data of this household [kWh].
     data_directory = '../source/profiles/data_load_profiles/household_load_profiles_htw'
-    # Get the name of the profile which ends with three numbers, so for id 5 the name would be
-    # ts_household_kWh_15min_2015_h005.
-    profile_name = 'ts_household_kWh_15min_2015_h' + str(int(id)).zfill(3) + '.csv'
+    # Get the name of the profile whose filename start with 1 and ends with three numbers, so for id 5 the name would be
+    # ts_household_kWh_15min_2015_h006.
+    profile_name = 'ts_household_kWh_15min_2015_h' + str(int(id_of_household) + 1).zfill(3) + '.csv'
     energy_load = csv_load_file(data_directory, profile_name)
     energy_load = energy_load[:n_step]
 
@@ -58,7 +65,7 @@ def eval_household(id):
 
 
 if __name__ == '__main__':
-    eval_household('5')
+    eval_household(9)
 
 
 

--- a/source/const.py
+++ b/source/const.py
@@ -10,7 +10,7 @@ num_minutes_in_a_day = 1440
 initial_coins_household = 10000000000
 
 """ Simulation environment """
-num_steps = int(96*15)
+num_steps = int(96*30)
 market_interval = 15  # minutes
 # Start time in UNIX (e.g. 1420070400 for 00:00:00-01.01.2015).
 # start_time = 1420070400
@@ -19,7 +19,7 @@ market_interval = 15  # minutes
 # initial_capacity = 0
 # max_size_ess = 10
 horizon = 24
-constraints_setting = "off"  # "off" or "on"
+constraints_setting = "on"  # "off" or "on"
 if constraints_setting == 'off':
     data_methods_log.warning("Physical battery constraints are not active")
 

--- a/source/devices.py
+++ b/source/devices.py
@@ -144,6 +144,7 @@ class ESS(object):
         """ independent charging limits check 
             should be done at bidding strategy as well
         """
+        # Getting the temperature [K].
         temperature = self.get_ess_temperature(self)
         self.temperature.append(temperature)
         [max_charge, max_discharge] = self.get_charging_limit()


### PR DESCRIPTION
… 1, which was not considered before (e.g. id 4 -> ts "....005.csv").